### PR TITLE
gschem: Refresh component library cache when reverting page.

### DIFF
--- a/gschem/src/i_callbacks.c
+++ b/gschem/src/i_callbacks.c
@@ -1539,6 +1539,9 @@ DEFINE_I_CALLBACK(page_revert)
   /* delete the page, then re-open the file as a new page */
   x_window_close_page (w_current, page_current);
 
+  /* Force symbols to be re-loaded from disk */
+  s_clib_refresh();
+
   page = x_window_open_page (w_current, filename);
   g_return_if_fail (page != NULL);
 

--- a/libgeda/src/s_clib.c
+++ b/libgeda/src/s_clib.c
@@ -767,9 +767,6 @@ static void refresh_scm (CLibSource *source)
  *  Resets the list of symbols available from each source, and
  *  repopulates it from scratch.  Useful e.g. for checking for new
  *  symbols.
- *
- *  \bug Disabled for now because it would break cached CLibSymbols used
- *  all over the place (e.g. in #st_object).
  */
 void s_clib_refresh ()
 {


### PR DESCRIPTION
Users sometimes use "File→Revert" in the hope of fixing things up when
symbols weren't found.

1. Open page
2. Symbols are missing
3. Copy symbols into expected place
4. Revert page

To make this work as expected, regenerate the symbol cache on page
revert.

Closes #28.