### PR TITLE
build: Fix issues related to gettext and desktop-i18n

### DIFF
--- a/README
+++ b/README
@@ -92,7 +92,7 @@ In order to compile gEDA from the distributed source archives, you
 
 The following tools and libraries are *highly recommended*:
 
- - GNU `gettext', version 0.16 or newer.
+ - GNU `gettext', version 0.18 or newer.
    <http://www.gnu.org/software/gettext/>
 
  - GNU `troff' (`groff'). <http://www.gnu.org/software/groff/>

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #                                                   -*-Shell-script-*-
 # Developer helper script for setting up gEDA build environment
-# Copyright (C) 2009  Peter Brett <peter@peter-b.co.uk>
+# Copyright (C) 2009, 2016  Peter Brett <peter@peter-b.co.uk>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -111,6 +111,11 @@ run_tool() {
 # the top-level po directory.  If it has, we copy the files to po
 # directories that we actually use.
 #
+# In newer versions of autopoint, there is a second bug whereby the
+# "intl" embedded internationalization library installed by autopoint
+# requires a "ChangeLog" file for "make dist", but doesn't actually
+# provide one.
+#
 # N.b. when this function is called we've cd'd into $srcdir.
 autopoint_fix() {
   top_po="po"
@@ -127,6 +132,12 @@ autopoint_fix() {
           cp -p $top_po/* $d || break
         done
       } && rm -rf $top_po
+    fi
+
+    cl="intl/ChangeLog"
+    if test -d "intl" -a ! -e "$cl"; then
+        echo "$script_name: creating file $cl"
+        touch "$cl"
     fi
   else
     exit $?

--- a/build-tools/desktop-i18n
+++ b/build-tools/desktop-i18n
@@ -1,7 +1,7 @@
 #!/bin/sh
 #                                                   -*-Shell-script-*-
 # Helper script for translating desktop integration data
-# Copyright (C) 2009-2010  Peter Brett <peter@peter-b.co.uk>
+# Copyright (C) 2009-2010, 2016  Peter Brett <peter@peter-b.co.uk>
 # Copyright (C) 2010       Dan McMahill <dan@mcmahill.net>
 #
 # This program is free software; you can redistribute it and/or modify
@@ -173,6 +173,10 @@ do_extract() {
       # uses full-length arguments, and we only really care about the
       # ones from there!
       case $name in
+        --version)
+          # We need to invoke xgettext with --version and do nothing else
+          exec $XGETTEXT --version;;
+
         --directory)  search_dirs="$search_dirs $value";;
         --files-from) file_lists="$file_lists $value";;
         --default-domain) domain="$value"; set x "$@" "$arg"; shift;;

--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ AC_PATH_PROGS([M4], [gm4 m4], [m4])
 
 AM_NLS
 AM_GNU_GETTEXT
-AM_GNU_GETTEXT_VERSION([0.16])
+AM_GNU_GETTEXT_VERSION([0.18])
 AX_DESKTOP_I18N
 
 #####################################################################


### PR DESCRIPTION
On some systems, `make distcheck` from a completely clean checkout of the geda-gaf repository was failing due to errors in the embedded `intl` library.  This library is installed into the source tree by the gettext **autopoint** tool.

Updating the configure script to a request version of **gettext** solves this.  However, it exposed a flaw in the `desktp-i18n` script's handling of **xgettext** command-line arguments; the `--version` argument was not being parsed and handled correctly.

There is also a (known) bug in autopoint 1.19, where `intl/ChangeLog` is not installed by autopoint despite being required when building a tarball. The `autogen.sh` script is updated to copy with _that_.