### PR TITLE
Enable "make distcheck" for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_install: >
 install: ./autogen.sh && ./configure --disable-update-xdg-database
 
 # Compile gEDA and run its tests
-script: make -ks all && make check
+script: make -kj4 distcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install: >
   sudo apt-get update && 
   sudo apt-get install -y \
     libgtk2.0-dev autopoint libgettextpo-dev libstroke0-dev \
-    guile-2.0-dev flex bison groff texinfo
+    guile-2.0-dev flex bison groff \
+    texinfo texlive-base texlive-generic-recommended texlive-latex-base
 
 # Set up the source tree by running autotools
 install: ./autogen.sh && ./configure --disable-update-xdg-database

--- a/Makefile.am
+++ b/Makefile.am
@@ -40,10 +40,8 @@ version.h: stamp-git $(top_builddir)/configure $(srcdir)/version.h.in
 
 	@date_ver=$(DATE_VERSION); dotted_ver=$(DOTTED_VERSION); \
 	git_commit=`cd $(srcdir) && $(GIT) rev-parse HEAD`; \
-	git_ver=`cd $(srcdir) && $(GIT) describe HEAD`; \
 	sed -e"s:^.*\(PACKAGE_DATE_VERSION\).*$$:#define \1 \"$$date_ver\":" \
 	    -e"s:^.*\(PACKAGE_DOTTED_VERSION\).*$$:#define \1 \"$$dotted_ver\":" \
-	    -e"s:^.*\(PACKAGE_GIT_VERSION\).*$$:#define \1 \"$$git_ver\":" \
 	    -e"s:^.*\(PACKAGE_GIT_COMMIT\).*$$:#define \1 \"$$git_commit\":" \
 	      < $(srcdir)/version.h.in > version.h.new; \
 	if diff version.h version.h.new > /dev/null 2>&1; then \

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ endif
 if XORN
   XORN_DIR = xorn
 endif
-SUBDIRS = intl libgeda libgedacairo gaf gschem ${GATTRIB_DIR} \
+SUBDIRS = libgeda libgedacairo gaf gschem ${GATTRIB_DIR} \
 	gsymcheck gnetlist utils symbols docs examples contrib $(XORN_DIR)
 
 ACLOCAL_AMFLAGS = -I m4

--- a/README
+++ b/README
@@ -81,6 +81,9 @@ In order to compile gEDA from the distributed source archives, you
  - GTK+ (the Gimp Toolkit), version 2.18.0 or later.
    <http://www.gtk.org/>
 
+ - GNU `gettext', version 0.18 or newer.
+   <http://www.gnu.org/software/gettext/>
+
  - The `lex' tool for generating lexical scanners.  The `flex'
    implementation recommended.  <http://flex.sourceforge.net/>
 
@@ -91,9 +94,6 @@ In order to compile gEDA from the distributed source archives, you
    headers.  <https://www.python.org/downloads/>
 
 The following tools and libraries are *highly recommended*:
-
- - GNU `gettext', version 0.18 or newer.
-   <http://www.gnu.org/software/gettext/>
 
  - GNU `troff' (`groff'). <http://www.gnu.org/software/groff/>
 

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ AC_PATH_PROGS([M4], [gm4 m4], [m4])
 #####################################################################
 
 AM_NLS
-AM_GNU_GETTEXT
+AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.18])
 AX_DESKTOP_I18N
 
@@ -203,7 +203,6 @@ AC_CONFIG_SUBDIRS([xorn])
 #####################################################################
 
 AC_CONFIG_FILES([Makefile
-                 intl/Makefile
 
                  libgeda/Makefile
                  libgeda/libgeda.pc

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -5,7 +5,11 @@ EXTRA_DIST = ChangeLog-1.0 ChangeLog
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO
 
 MOSTLYCLEANFILES = *.log core FILE *~

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -9,7 +9,11 @@ EXTRA_DIST = ChangeLog ChangeLog-1.0 $(example_DATA)
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO
 
 MOSTLYCLEANFILES = *.log core FILE *~ 

--- a/gaf/Makefile.am
+++ b/gaf/Makefile.am
@@ -24,8 +24,7 @@ gaf_SOURCES = \
 	shell.c
 
 gaf_CPPFLAGS = \
-	-I$(top_srcdir) -I$(top_srcdir)/libgeda/include -I$(includedir) \
-	-I$(top_srcdir)/intl
+	-I$(top_srcdir) -I$(top_srcdir)/libgeda/include -I$(includedir)
 gaf_CFLAGS = \
 	$(GCC_CFLAGS) $(MINGW_CFLAGS) $(GUILE_CFLAGS) $(GTK_CFLAGS) \
 	$(GDK_PIXBUF_CFLAGS) $(CAIRO_CFLAGS) $(CAIRO_PNG_CFLAGS) \
@@ -34,8 +33,7 @@ gaf_LDFLAGS = $(GUILE_LIBS) $(GTK_LIBS) $(GDK_PIXBUF_LIBS) $(CAIRO_LIBS) \
 	$(CAIRO_PNG_LIBS) $(CAIRO_PDF_CLAGS) $(CAIRO_PS_LIBS) $(CAIRO_SVG_LIBS)
 gaf_LDADD = \
 	$(top_builddir)/libgedacairo/libgedacairo.la \
-	$(top_builddir)/libgeda/src/libgeda.la \
-	@LIBINTL@
+	$(top_builddir)/libgeda/src/libgeda.la
 
 localedir = @datadir@/locale
 DEFS = -DLOCALEDIR=\"$(localedir)\" @DEFS@

--- a/gaf/Makefile.am
+++ b/gaf/Makefile.am
@@ -6,7 +6,11 @@ EXTRA_DIST = $(html_man_files) gaf.1.in ChangeLog
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO
 
 BUILT_SOURCES = shell.x

--- a/gattrib/Makefile.am
+++ b/gattrib/Makefile.am
@@ -4,7 +4,11 @@ EXTRA_DIST = BUGS NOTES README ChangeLog ChangeLog-1.0 ToDos
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO
 
 MOSTLYCLEANFILES = *.log core FILE *~ #*#

--- a/gnetlist/Makefile.am
+++ b/gnetlist/Makefile.am
@@ -5,7 +5,11 @@ EXTRA_DIST = BUGS ChangeLog ChangeLog-1.0
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO
 
 MOSTLYCLEANFILES = *.log core FILE *~

--- a/gschem/Makefile.am
+++ b/gschem/Makefile.am
@@ -6,7 +6,11 @@ EXTRA_DIST = BUGS ChangeLog ChangeLog-1.0 icon-theme-installer
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO
 
 maintainer-clean-local:

--- a/gschem/src/Makefile.am
+++ b/gschem/src/Makefile.am
@@ -118,7 +118,7 @@ gschem_SOURCES = \
 	x_window.c
 
 gschem_CPPFLAGS = -I$(top_srcdir)/libgeda/include  -I$(srcdir)/../include \
-	-I$(top_srcdir) -I$(includedir) -I$(top_srcdir)/intl
+	-I$(top_srcdir) -I$(includedir)
 gschem_CFLAGS = $(GCC_CFLAGS) $(LIBSTROKE_CFLAGS) \
 	$(MINGW_CFLAGS) \
 	$(GLIB_CFLAGS) $(GTK_CFLAGS) $(GTHREAD_CFLAGS) $(GUILE_CFLAGS)
@@ -126,8 +126,7 @@ gschem_LDFLAGS = $(LIBSTROKE_LDFLAGS) $(GLIB_LIBS) $(GTK_LIBS) \
 	$(GTHREAD_LIBS) $(GUILE_LIBS) $(MINGW_GUI_LDFLAGS)
 gschem_LDADD = \
 	$(top_builddir)/libgedacairo/libgedacairo.la \
-	$(top_builddir)/libgeda/src/libgeda.la \
-	@LIBINTL@
+	$(top_builddir)/libgeda/src/libgeda.la
 
 
 # This is used to generate boilerplate for defining Scheme functions

--- a/gsymcheck/Makefile.am
+++ b/gsymcheck/Makefile.am
@@ -5,7 +5,11 @@ EXTRA_DIST = BUGS ChangeLog ChangeLog-1.0
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO
 
 MOSTLYCLEANFILES = *.log core FILE *~

--- a/libgeda/Makefile.am
+++ b/libgeda/Makefile.am
@@ -12,7 +12,11 @@ libgeda-pc-install: libgeda.pc
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO
 
 MOSTLYCLEANFILES = *.log core FILE *~

--- a/libgeda/po/POTFILES.in
+++ b/libgeda/po/POTFILES.in
@@ -36,6 +36,3 @@ libgeda/src/scheme_page.c
 libgeda/src/edascmhookproxy.c
 
 libgeda/scheme/geda/attrib.scm
-
-intl/plural.c
-

--- a/libgeda/tests/Makefile.am
+++ b/libgeda/tests/Makefile.am
@@ -46,5 +46,4 @@ AM_LDFLAGS = -version-info $(LIBGEDA_SHLIB_VERSION) \
 	$(WINDOWS_LIBTOOL_FLAGS) $(MINGW_LDFLAGS) $(GUILE_LIBS) \
 	$(GLIB_LIBS) $(GDK_PIXBUF_LIBS) \
 	$(top_builddir)/libgedacairo/libgedacairo.la \
-	$(top_builddir)/libgeda/src/libgeda.la \
-	@LIBINTL@
+	$(top_builddir)/libgeda/src/libgeda.la

--- a/libgedacairo/Makefile.am
+++ b/libgedacairo/Makefile.am
@@ -33,5 +33,9 @@ pkgconfig_DATA = libgedacairo.pc
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO

--- a/m4/geda-git-version.m4
+++ b/m4/geda-git-version.m4
@@ -1,8 +1,8 @@
 # geda-git-version.m4                                   -*-Autoconf-*-
-# serial 2
+# serial 3
 
 dnl Extract gEDA version parameters from a git repository, if present.
-dnl Copyright (C) 2009-2011  Peter Brett <peter@peter-b.co.uk>
+dnl Copyright (C) 2009-2011, 2016  Peter Brett <peter@peter-b.co.uk>
 dnl
 dnl This program is free software; you can redistribute it and/or modify
 dnl it under the terms of the GNU General Public License as published by
@@ -38,25 +38,38 @@ changequote([,])
   # describe.
   if test "X$HAVE_GIT_REPO" = "Xyes"; then
     AC_MSG_CHECKING([version from git repository])
-    GIT_VERSION=`cd $srcdir && $GIT describe`
+    GIT_VERSION=`cd $srcdir && $GIT rev-parse HEAD 2>/dev/null`
     AC_MSG_RESULT([$GIT_VERSION])
+
+    AC_MSG_CHECKING([descriptive git version])
+    GIT_DESCRIBE_VERSION=`cd $srcdir && $GIT describe 2>/dev/null`
+    if test "$?" = "0"; then
+      AC_MSG_RESULT([$GIT_DESCRIBE_VERSION])
+    else
+      AC_MSG_RESULT([no])
+    fi
   fi
 
   # If there's an annotated tag available, test that the git version
   # and AC_INIT versions agree.
-  if (cd $srcdir && git describe > /dev/null); then
+  if test "X$GIT_DESCRIBE_VERSION" != "X"; then
+    AC_MSG_CHECKING([whether git version matches configured version])
 changequote(,)
     git_sed_pattern="^\([^-]*\)-\([^-]*\).*"
 changequote([,])
-    GIT_DOTTED_VERSION=`echo $GIT_VERSION | sed -e"s/$git_sed_pattern/\1/"`
-    GIT_DATE_VERSION=`echo $GIT_VERSION | sed -e"s/$git_sed_pattern/\2/"`
+    GIT_DOTTED_VERSION=`echo $GIT_DESCRIBE_VERSION |
+                        sed -e"s/$git_sed_pattern/\1/"`
+    GIT_DATE_VERSION=`echo $GIT_DESCRIBE_VERSION |
+                      sed -e"s/$git_sed_pattern/\2/"`
 
     if (test "X$GIT_DOTTED_VERSION" != "X$DOTTED_VERSION") ||
        (test "X$GIT_DATE_VERSION" != "X$DATE_VERSION");
     then
-
+      AC_MSG_RESULT([no])
       AC_MSG_WARN([The latest git tag name doesn't appear to match the version specified
 by the configure script.])
+    else
+      AC_MSG_RESULT([yes])
     fi
   fi
 

--- a/symbols/Makefile.am
+++ b/symbols/Makefile.am
@@ -59,7 +59,11 @@ EXTRA_DIST = ChangeLog ChangeLog-1.0 \
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO
 
 # Copies symbols into distribution

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -6,7 +6,11 @@ EXTRA_DIST = ChangeLog ChangeLog.tragesym-1.0 ChangeLog.gsch2pcb-1.0 \
 
 if HAVE_GIT_REPO
 ChangeLog: $(top_builddir)/stamp-git
-	(cd $(srcdir) && $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- .) > $@
+	( \
+	  cd $(srcdir) && \
+	  $(GIT) log --pretty=medium $(CHANGELOG_BASE).. -- . || \
+	  echo "WARNING: ChangeLog information not available from git" >&2 ; \
+	) > $@
 endif HAVE_GIT_REPO
 
 MOSTLYCLEANFILES = *.log core FILE *~

--- a/version.h.in
+++ b/version.h.in
@@ -6,6 +6,3 @@
 
 /* Current git commit. */
 /* #undef PACKAGE_GIT_COMMIT */
-
-/* Current 'git describe' version string. */
-/* #undef PACKAGE_GIT_VERSION */


### PR DESCRIPTION
Make changes to enable running tests on Travis CI using `make distcheck`.  This makes it much easier to ensure that changes don't break the build.

* Ensure that `make dist` can succeed when run from a shallow git repository, by tweaking `ChangeLog` generation and configure checks

* Stop bundling libintl in the distributed tarball -- apparently it really, really doesn't like to build on modern toolchains (I can't even get it to build locally).  This makes GNU gettext effectively a hard dependency -- if you don't have it available, then no i18n is available.  However, that seems like a reasonable compromise