### PR TITLE
scheme-api: Add log! procedure

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,6 +32,10 @@ Notable changes in gEDA/gaf 1.9.2.1p
   disabled, which may break backward-compatibility with some
   configurations.
 
+* A new Scheme API function, `log!`, has been added to the `(geda
+  log)` module.  It allows Scheme code to emit log messages in the
+  same way that the tools' C code does.
+
 Notable changes in gEDA/gaf 1.9.2
 =================================
 * Build system changes:

--- a/docs/scheme-api/geda-scheme.texi
+++ b/docs/scheme-api/geda-scheme.texi
@@ -344,6 +344,7 @@ available to be used in all gEDA applications.
 * Core object functions::
 * Core attribute functions::
 * Configuration functions::
+* Logging functions::
 * System information::
 @end menu
 
@@ -2013,6 +2014,25 @@ A requested configuration group was not found.
 @item invalid-value
 A configuration value could not be parsed into the requested format.
 @end table
+
+@node Logging functions
+@section Logging functions
+
+To use the functions described in this section, you will need to load
+the @code{(geda log)} module.
+
+@defun log! level message [format-args...]
+Emit a log message with the specified @var{level}.  The @var{message}
+is interpreted as a format string, with @var{format-args} as its
+parameters.
+
+The @var{level} should be one of the symbols @code{error},
+@code{critical}, @code{warning}, @code{message}, @code{info} or
+@code{debug}.
+
+Generally, if the @var{level} is not @code{debug}, then the message
+should be localised.
+@end defun
 
 @node System information
 @section System information

--- a/libgeda/include/libgedaguile_priv.h
+++ b/libgeda/include/libgedaguile_priv.h
@@ -94,6 +94,7 @@ void edascm_init_attrib ();
 void edascm_init_os ();
 void edascm_init_config ();
 void edascm_init_closure (void);
+void edascm_init_log (void);
 void edascm_init_deprecated ();
 
 /* ---------------------------------------- */

--- a/libgeda/scheme/Makefile.am
+++ b/libgeda/scheme/Makefile.am
@@ -3,7 +3,7 @@ scmdatadir = $(GEDADATADIR)/scheme
 nobase_dist_scmdata_DATA = \
 	geda.scm geda-deprecated-config.scm color-map.scm \
 	geda/object.scm geda/page.scm geda/attrib.scm geda/deprecated.scm \
-	geda/os.scm geda/config.scm geda/log-rotate.scm
+	geda/os.scm geda/config.scm geda/log-rotate.scm geda/log.scm
 nobase_scmdata_DATA = geda/core/gettext.scm
 
 check-am: update-gaf-tool

--- a/libgeda/scheme/geda/log.scm
+++ b/libgeda/scheme/geda/log.scm
@@ -1,0 +1,52 @@
+;; gEDA - GPL Electronic Design Automation
+;; libgeda - gEDA's library - Scheme API
+;; Copyright (C) 2016 Peter Brett <peter@peter-b.co.uk>
+;;
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, write to the Free Software
+;; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
+;;
+
+(define-module (geda log)
+  #:use-module (geda core log)
+  #:use-module (geda core gettext)
+
+  #:use-module (geda os)
+  #:use-module (ice-9 format)
+  #:use-module (ice-9 ftw)
+  #:use-module (ice-9 match)
+  #:use-module (ice-9 regex)
+  #:use-module (srfi srfi-1)
+  #:use-module (srfi srfi-19)
+  #:use-module (srfi srfi-26))
+
+;; ================================================================
+;; Logging messages
+;; ================================================================
+
+#|
+Function::
+
+  log! level message [format-args]
+
+Log a new message with the specified log level and contents.
+
+The LEVEL should describe the log level -- for example, one of the
+symbols "message", "warning", "critical", "error", "info" or
+"debug".  "error"-level messages are fatal.
+
+A newline character is automatically appended to the message.
+|#
+(define-public (log! level message . format-args)
+  (let ((formatted (apply format #f message format-args)))
+    (%log! #f level (string-append formatted))))

--- a/libgeda/src/Makefile.am
+++ b/libgeda/src/Makefile.am
@@ -13,6 +13,7 @@ BUILT_SOURCES = \
 	scheme_os.x \
 	scheme_config.x \
 	scheme_closure.x \
+	scheme_log.x \
 	scheme_deprecated.x
 
 scheme_api_sources = \
@@ -27,6 +28,7 @@ scheme_api_sources = \
 	scheme_config.c \
 	scheme_closure.c \
 	scheme_deprecated.c \
+	scheme_log.c \
 	edascmhookproxy.c \
 	edascmvaluetypes.c
 

--- a/libgeda/src/scheme_init.c
+++ b/libgeda/src/scheme_init.c
@@ -50,6 +50,7 @@ edascm_init_impl (void *data)
   edascm_init_os ();
   edascm_init_config ();
   edascm_init_closure ();
+  edascm_init_log ();
   edascm_init_deprecated ();
   return NULL;
 }

--- a/libgeda/src/scheme_log.c
+++ b/libgeda/src/scheme_log.c
@@ -1,0 +1,140 @@
+/* gEDA - GPL Electronic Design Automation
+ * libgeda - gEDA's library - Scheme API
+ * Copyright (C) 2016  Peter Brett <peter@peter-b.co.uk>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111 USA
+ */
+
+/*!
+ * \file scheme_log.c
+ * \brief Scheme API logging support
+ */
+
+#include <config.h>
+
+#include "libgeda_priv.h"
+#include "libgedaguile_priv.h"
+
+SCM_SYMBOL(error_sym, "error");
+SCM_SYMBOL(critical_sym, "critical");
+SCM_SYMBOL(warning_sym, "warning");
+SCM_SYMBOL(message_sym, "message");
+SCM_SYMBOL(info_sym, "info");
+SCM_SYMBOL(debug_sym, "debug");
+
+
+/*! \brief Convert a Scheme symbol to log level flags.
+ * \par Function Description
+ * Helper function to construct a #GLogLevelFlags value from a Scheme
+ * symbol.
+ */
+static GLogLevelFlags
+decode_level (SCM level_s)
+{
+	if (level_s == error_sym)    return (G_LOG_LEVEL_ERROR | G_LOG_FLAG_FATAL);
+	if (level_s == critical_sym) return G_LOG_LEVEL_CRITICAL;
+	if (level_s == warning_sym)  return G_LOG_LEVEL_WARNING;
+	if (level_s == message_sym)  return G_LOG_LEVEL_MESSAGE;
+	if (level_s == info_sym)     return G_LOG_LEVEL_INFO;
+	if (level_s == debug_sym)    return G_LOG_LEVEL_DEBUG;
+
+	g_return_val_if_reached(G_LOG_LEVEL_MESSAGE);
+}
+
+/* ================================================================
+ * Functions for use from Scheme
+ * ================================================================ */
+
+/*! \brief Log a message.
+ * \par Function Description
+ * Add a message to the message log.  The \a domain_s should normally
+ * be SCM_BOOL_F, and the \a message_s should almost always be
+ * translated for all log levels other than "debug".  The \a level_s
+ * should be one of the symbols "error", "critical", "message", "info"
+ * or "debug".
+ *
+ * \note Scheme API: Implements the \%log! procedure in the (geda core
+ * log) module.
+ *
+ * \param domain_s  The log domain, as a string, or SCM_BOOL_F.
+ * \param level_s   The log level, as a symbol.
+ * \param message_s The log message, as a string.
+ *
+ * \return undefined.
+ */
+SCM_DEFINE (log_x, "%log!", 3, 0, 0,
+            (SCM domain_s, SCM level_s, SCM message_s),
+            "Emit a log message.")
+{
+	SCM_ASSERT (scm_is_false(domain_s) || scm_is_string(domain_s), domain_s,
+	            SCM_ARG1, s_log_x);
+	SCM_ASSERT (scm_is_symbol(level_s), level_s,
+	            SCM_ARG2, s_log_x);
+	SCM_ASSERT (scm_is_string(message_s), message_s,
+	            SCM_ARG3, s_log_x);
+
+	scm_dynwind_begin(0);
+	gchar *domain = NULL;
+	if (domain) {
+		scm_to_utf8_string(domain_s);
+		scm_dynwind_free(domain);
+	}
+	gchar *message = scm_to_utf8_string(message_s);
+	scm_dynwind_free(message);
+	GLogLevelFlags level = decode_level(level_s);
+
+	g_log(domain, level, message);
+
+	scm_dynwind_end();
+
+	return SCM_UNSPECIFIED;
+}
+
+/* ================================================================
+ * Initialization
+ * ================================================================ */
+
+/*!
+ * \brief Create the (geda core log) Scheme module.
+ * \par Function Description
+ * Defines procedures in the (geda core log) module.  The module can
+ * be accessed using (use-modules (geda core log)).
+ */
+static void
+init_module_geda_core_log ()
+{
+	/* Register the functions and symbols */
+	#include "scheme_log.x"
+
+	/* Add them to the module's public definitions */
+	scm_c_export (s_log_x,
+	              NULL);
+}
+
+/*!
+ * \brief Initialise the basic gEDA logging procedures
+ * \par Function Description
+ *
+ * Registers some core Scheme procedures for logging support.  Should
+ * only be called by edascm_init().
+ */
+void
+edascm_init_log ()
+{
+	/* Define the (geda core log) module */
+	scm_c_define_module ("geda core log",
+	                     init_module_geda_core_log,
+	                     NULL);
+}


### PR DESCRIPTION
The new `log!` procedure allows Scheme code to send log messages through the same GLib message logging API used by the parts of gschem that are implemented in C.