### PR TITLE
gnetlist: Workaround some poor behaviour in rename tracking

### DIFF
--- a/gnetlist/src/s_rename.c
+++ b/gnetlist/src/s_rename.c
@@ -153,11 +153,25 @@ int s_rename_search(char *src, char *dest, int quiet_flag)
     return (FALSE);
 }
 
+static int
+s_rename_compare_strings (const RENAME *rename,
+                          const char *src,
+                          const char *dest)
+{
+  return (0 == strcmp(rename->src, src) &&
+          0 == strcmp(rename->dest, dest));
+}
+
 static void s_rename_add_lowlevel (const char *src, const char *dest)
 {
     RENAME *new_rename;
 
     g_return_if_fail(last_set != NULL);
+
+    /* Avoid adding unnecessary duplicate renames */
+    if (s_rename_compare_strings(last_set->last_rename, src, dest)) {
+      return;
+    }
 
     new_rename = g_malloc(sizeof (RENAME));
 


### PR DESCRIPTION
A memory exhaustion bug was reported in gnetlist, where netlisting a
set of similar schematics was causing excess allocation by the rename
tracking code.  Testing suggested that `s_rename_add_lowlevel()` was
being called repeatedly with identical `src` and `dest` arguments.

In order to avoid searching the whole rename list for each added
rename (with potentially O(N^2) performance), this patch makes
`s_rename_add_lowlevel()` only add a new rename if the latest rename
isn't identical.